### PR TITLE
Make enums be inner classes

### DIFF
--- a/Holy Grail Sort/Java/Summer Dragonfly et al.'s Rough Draft/src/holygrail/HolyGrailSort.java
+++ b/Holy Grail Sort/Java/Summer Dragonfly et al.'s Rough Draft/src/holygrail/HolyGrailSort.java
@@ -63,19 +63,19 @@ import java.util.Comparator;
  * Special thanks to "The Studio" Discord community!
  */
 
-enum LocalMerge {
-    FORWARDS,
-    BACKWARDS;
-}
-
-//Credit to phoenixbound for this clever idea
-enum Subarray {
-    LEFT,
-    RIGHT;
-}
-
 @SuppressWarnings("hiding")
 final public class HolyGrailSort<T> {
+    enum LocalMerge {
+        FORWARDS,
+        BACKWARDS;
+    }
+
+    //Credit to phoenixbound for this clever idea
+    enum Subarray {
+        LEFT,
+        RIGHT;
+    }
+
     private Comparator<T> cmp;
 
     final static int STATIC_EXT_BUFFER_LEN = 512;


### PR DESCRIPTION
This moves the enums `LocalMerge` and `Subarray` to be *inside* the `HolyGrailSort` class. This makes it so that they compile to `HolyGrailSort$LocalMerge.class` and `HolyGrailSort$Subarray.class`, respectively, making file organization easier.